### PR TITLE
"03 scale" phase  fixes: cookies for auth, prod push trigger in deploy github action

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - prod
 
 jobs:
   build:

--- a/terraform/module/cluster/distribution.tf
+++ b/terraform/module/cluster/distribution.tf
@@ -36,7 +36,7 @@ resource "aws_cloudfront_distribution" "this" {
       query_string = true
 
       cookies {
-        forward = "none"
+        forward = "all"
       }
     }
   }


### PR DESCRIPTION
Includes two small fixes so that the end solution (to the 03 scale phase) works completely:

### Add 'prod' branch "on" trigger to build and deploy workflow

Without this, you can't deploy to prod because it will only trigger on pushes to main

### Change cluster cookie forwarding from 'none' to 'all'

Without this fix, google auth won't work on the service. Instead, you'll go through the oauth flow, but land back at the logged out page because the service doesn't get the resulting auth cookies