### PR TITLE
Upgrade PostgreSQL Docker image to version 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_PASSWORD: password 
     network_mode: host


### PR DESCRIPTION
## Summary
Updated the PostgreSQL Docker image in docker-compose.yml to use the latest stable version (17) while maintaining the Alpine Linux base image for a lightweight container.

## Key Changes
- Upgraded PostgreSQL image from `postgres:alpine` to `postgres:17-alpine`

## Implementation Details
This change ensures the development and deployment environment uses PostgreSQL 17, which includes the latest features, performance improvements, and security updates. The Alpine Linux base image is retained to keep the container image size minimal.

Closes #10 